### PR TITLE
Update xash3d.sh

### DIFF
--- a/packages/sx05re/emuelec-ports/xash3d/files/xash3d.sh
+++ b/packages/sx05re/emuelec-ports/xash3d/files/xash3d.sh
@@ -6,7 +6,7 @@
 # Source predefined functions and variables
 . /etc/profile
 
-XHAS3D_LIBS="/usr/lib/xash3d/usr/valve"
+XHAS3D_LIBS="/usr/lib/xash3d/valve"
 
 # Exports for xash3d
 export XASH3D_BASEDIR=/storage/roms/ports/half-life


### PR DESCRIPTION
referencing the incorrect folder /usr/lib/xash3d/usr/valve instead of /usr/lib/xash3d/valve. on a fresh install of 4.7 i got a couple of errors in the log where the files in cl_dlls and dlls were unable to be found.